### PR TITLE
Modified calavera.up.sh to be sure that we don't get duplicated lines in hostfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation instructions
 - Everytime you want to re/start the environment, use:
   - ``./calavera.startup.sh`` 
   - This will make the environment up and running in case it was in an unstabe state.
-- Be careful with your DNS settings. When using the dnsmasq container, it's important to keep in mind that it will use the information in the ``/etc/resolv.conf`` of the host system and that content is usually a dynamic configuration. You will need that the DNS server points to the local IP@ where the docker dnsmasq server is bound (usually eth0). So you shoud:
+- Be careful with your DNS settings. As stated here ( http://stackoverflow.com/questions/23012273/setting-up-docker-dnsmasq) When using the dnsmasq container, it's important to keep in mind that it will use the information in the ``/etc/resolv.conf`` of the host system and that content is usually a dynamic configuration. You will need that the DNS server points to the local IP@ where the docker dnsmasq server is bound (usually eth0). So you shoud:
   - Set up the ``/etc/resolv.conf`` file adding a line that says ``nameserver 172.16.251.151``
   - ``sudo docker stop dnsmasq``
   - ``sudo docker start dnsmasq``

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Installation instructions
 - Everytime you want to re/start the environment, use:
   - ``./calavera.startup.sh`` 
   - This will make the environment up and running in case it was in an unstabe state.
+- Be careful with your DNS settings. When using the dnsmasq container, it's important to keep in mind that it will use the information in the ``/etc/resolv.conf`` of the host system and that content is usually a dynamic configuration. You will need that the DNS server points to the local IP@ where the docker dnsmasq server is bound (usually eth0). So you shoud:
+  - Set up the ``/etc/resolv.conf`` file adding a line that says ``nameserver 172.16.251.151``
+  - ``sudo docker stop dnsmasq``
+  - ``sudo docker start dnsmasq``
+  
 
 Calavera
 ========

--- a/calavera.up.sh
+++ b/calavera.up.sh
@@ -5,5 +5,7 @@ NODE=$1
     vagrant reload ${NODE}
     echo "-- Adding \"${NODE}\" to dns"
     C_IP=`docker inspect --format='{{.NetworkSettings.IPAddress}}' ${NODE}`
-    echo "${C_IP} ${NODE} ${NODE}.calavera.biz" >> dnsmasq.hosts/calavera
+    grep -v ${NODE} dnsmasq.hosts/calavera > /tmp/calavera.tmp
+    echo "${C_IP} ${NODE} ${NODE}.calavera.biz" >> /tmp/calavera.tmp
+    mv /tmp/calavera.tmp dnsmasq.hosts/calavera
     docker kill -s HUP dnsmasq


### PR DESCRIPTION
Added some instructions to allow the host computer to use the dnsmasq container as primary DNS and therefore be able to resolve all the Calavera project servernames.
